### PR TITLE
fix: return config to the previous state

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -20,6 +20,27 @@ module.exports = {
         path: `${__dirname}/src/pages/`,
       },
     },
+    'gatsby-transformer-sharp',
+    {
+      resolve: 'gatsby-plugin-sharp',
+      options: {
+        useMozJpeg: false,
+        stripMetadata: true,
+        defaultQuality: 75,
+      },
+    },
+    {
+      resolve: 'gatsby-plugin-manifest',
+      options: {
+        name: 'gatsby-starter-default',
+        short_name: 'starter',
+        start_url: '/',
+        background_color: '#663399',
+        theme_color: '#663399',
+        display: 'minimal-ui',
+        icon: 'src/images/gatsby-icon.png', // This path is relative to the root of the site.
+      },
+    },
     'gatsby-plugin-netlify-cms',
     'gatsby-transformer-remark',
   ],


### PR DESCRIPTION
Gatsby-config.js changed because of fail commit while aditting the project on 32-bit Windows OS. This change is to return the previous version of gatsby-config.js to restore the images view.